### PR TITLE
feat: add migrate worflow

### DIFF
--- a/.github/workflows/db-migrate.yaml
+++ b/.github/workflows/db-migrate.yaml
@@ -1,0 +1,58 @@
+name: Database Migrations
+
+on:
+  workflow_run:
+    workflows: ["Terraform Apply (DB)"]  # Nome do fluxo de trabalho do banco
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  migrate:
+    name: Migrate
+    runs-on: ubuntu-latest
+    needs: terraform-db-apply
+    environment: production
+    steps:
+      - name: Checkout application repository
+        uses: actions/checkout@v3
+        with:
+          repository: lucaschf/tech-challenge-phase-1
+          path: /
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get DB Connection Details (from remote state)
+        uses: aws-actions/aws-cli@v1
+        with:
+          args: >-
+            terraform output -json 
+            --state=s3://seu-bucket-terraform-state/terraform.tfstate 
+            --no-color
+
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ env.AWS_REGION }} # Ou defina diretamente
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run migrations
+        run: |
+          alembic upgrade head
+        env:
+          DATABASE_URL: postgresql://${{ fromJson(steps.get_db_details.outputs.stdout).db_username }}:${{ secrets.DB_PASSWORD }}@${{ fromJson(steps.get_db_details.outputs.stdout).db_endpoint }}:${{ fromJson(steps.get_db_details.outputs.stdout).db_port }}/${{ fromJson(steps.get_db_details.outputs.stdout).db_name }}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a GitHub Actions workflow to automate database migrations post Terraform deployment.

CI:
- Add a new GitHub Actions workflow for database migrations triggered after the Terraform Apply (DB) workflow completes.

<!-- Generated by sourcery-ai[bot]: end summary -->