### PR TITLE
feat: add more time to deploy

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: tech-challenge-phase-1-api
 spec:
+  progressDeadlineSeconds: 600
   selector:
     matchLabels:
       app: tech-challenge-phase-1-api


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Extend the progress deadline for Kubernetes deployments to allow more time for the deployment process to complete.

Deployment:
- Increase the progress deadline for Kubernetes deployments to 600 seconds.

<!-- Generated by sourcery-ai[bot]: end summary -->