### PR TITLE
feat: reduce deploy time

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: tech-challenge-phase-1-api
 spec:
-  progressDeadlineSeconds: 600
   selector:
     matchLabels:
       app: tech-challenge-phase-1-api


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the 'progressDeadlineSeconds' setting from the Kubernetes deployment configuration to potentially reduce deployment time.

Deployment:
- Remove the 'progressDeadlineSeconds' setting from the Kubernetes deployment configuration to potentially reduce deployment time.

<!-- Generated by sourcery-ai[bot]: end summary -->